### PR TITLE
feat: add charting and historical stats

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ importers:
       '@types/react-dom': 18.0.1
       '@vercel/analytics': ^0.1.5
       autoprefixer: ^10.4.4
+      chart.js: 4.1.2
+      chartjs-adapter-date-fns: 3.0.0
+      date-fns: 2.29.3
       eslint: 8.13.0
       eslint-config-next: 12.1.5
       next: 13.0.6
@@ -16,15 +19,20 @@ importers:
       nextra-theme-docs: 2.0.1
       postcss: ^8.4.12
       react: ^18.0.0
+      react-chartjs-2: 5.2.0
       react-dom: ^18.0.0
       tailwindcss: ^3.0.24
       typescript: 4.6.3
     dependencies:
       '@vercel/analytics': 0.1.5_react@18.2.0
+      chart.js: 4.1.2
+      chartjs-adapter-date-fns: 3.0.0_kluv2ktejb2igagp3yc56zuwiy
+      date-fns: 2.29.3
       next: 13.0.6_biqbaboplfbrettd7655fr4n2y
       nextra: 2.0.1_6jx7hpii6hgsrmhxgqrmo3277u
       nextra-theme-docs: 2.0.1_6jx7hpii6hgsrmhxgqrmo3277u
       react: 18.2.0
+      react-chartjs-2: 5.2.0_mfjxiilvrceiwtanada6fxhije
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@types/node': 17.0.24
@@ -104,6 +112,10 @@ packages:
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
+
+  /@kurkle/color/0.3.2:
+    resolution: {integrity: sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==}
+    dev: false
 
   /@mdx-js/mdx/2.1.5:
     resolution: {integrity: sha512-zEG0lt+Bl/r5U6e0TOS7qDbsXICtemfAPquxWFsMbdzrvlWaqMGemLl+sjVpqlyaaiCiGVQBSGdCk0t1qXjkQg==}
@@ -835,6 +847,23 @@ packages:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
     dev: false
 
+  /chart.js/4.1.2:
+    resolution: {integrity: sha512-9L1w6WLPq6ztiWVVOYtDtpo0CUsBKDWPrUEdwChAyzczaikqeSwNKEv3QpJ7EO4ICcLSi6UDVhgvcnUhRJidRA==}
+    engines: {pnpm: ^7.0.0}
+    dependencies:
+      '@kurkle/color': 0.3.2
+    dev: false
+
+  /chartjs-adapter-date-fns/3.0.0_kluv2ktejb2igagp3yc56zuwiy:
+    resolution: {integrity: sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==}
+    peerDependencies:
+      chart.js: '>=2.8.0'
+      date-fns: '>=2.0.0'
+    dependencies:
+      chart.js: 4.1.2
+      date-fns: 2.29.3
+    dev: false
+
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -933,6 +962,11 @@ packages:
   /damerau-levenshtein/1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
+
+  /date-fns/2.29.3:
+    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+    engines: {node: '>=0.11'}
+    dev: false
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3050,6 +3084,16 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
     dev: true
+
+  /react-chartjs-2/5.2.0_mfjxiilvrceiwtanada6fxhije:
+    resolution: {integrity: sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==}
+    peerDependencies:
+      chart.js: ^4.1.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      chart.js: 4.1.2
+      react: 18.2.0
+    dev: false
 
   /react-dom/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}

--- a/sites/stc/package.json
+++ b/sites/stc/package.json
@@ -10,10 +10,14 @@
   },
   "dependencies": {
     "@vercel/analytics": "^0.1.5",
+    "chart.js": "4.1.2",
+    "chartjs-adapter-date-fns": "3.0.0",
+    "date-fns": "2.29.3",
     "next": "13.0.6",
     "nextra": "2.0.1",
     "nextra-theme-docs": "2.0.1",
     "react": "^18.0.0",
+    "react-chartjs-2": "5.2.0",
     "react-dom": "^18.0.0"
   },
   "devDependencies": {

--- a/sites/stc/pages/index.mdx
+++ b/sites/stc/pages/index.mdx
@@ -3,27 +3,165 @@ title: "STC: Speedy type checker"
 ---
 
 import { useSSG } from 'nextra/ssg'
+import { Chart as ChartJS, Colors, LinearScale, TimeScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js'
+import 'chartjs-adapter-date-fns'
+import { Line } from 'react-chartjs-2'
 
-export const getStaticProps = ({ params }) => {
-  return fetch(`https://api.github.com/repos/dudykr/stc/contents/crates/stc_ts_type_checker/tests/tsc-stats.rust-debug`)
-    .then(res => res.json())
-    .then(repo => ({
+export const normalizeJson = (string) => {
+    // REFER: see https://stackoverflow.com/a/60708762
+    return string.replace(/[\s\n\r\t]/gs, '').replace(/,([}\]])/gs, '$1')
+      .replace(/([,{\[]|)(?:("|'|)([\w_\- ]+)\2:|)("|'|)(.*?)\4([,}\]])/gs, (str, start, q1, index, q2, item, end) => {
+        item = item.replace(/"/gsi, '').trim()
+        if (index) { index = '"'+index.replace(/"/gsi, '').trim() + '"' }
+        if (!item.match(/^[0-9]+(\.[0-9]+|)$/) && !['true','false'].includes(item)) { item = '"' + item + '"' }
+        if (index) { return start + index + ':' + item + end }
+        return start + item + end
+    })
+}
+
+export const getCommits = async (ghToken, owner, repo, filename) => {
+  if (!ghToken || !ghToken.length) {
+    throw new Error('Github API token missing! Please configure it with the environment variable GITHUB_TOKEN')
+  }
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/commits?path=${filename}`, {
+    headers: {
+      'Authorization': `token ${ghToken}`,
+    },
+  })
+  const json = await response.json()
+  return json
+}
+
+export const getStats = async (ghToken, owner, repo, filename) => {
+  const commits = await getCommits(ghToken, owner, repo, filename)
+  const versionFetchers = commits.map(commit => fetch(`https://raw.githubusercontent.com/${owner}/${repo}/${commit.sha}/${filename}`))
+  const allVersions = await Promise.all(versionFetchers)
+  const rawStats = await Promise.all(allVersions.map(r => r.text()))
+  const stats = rawStats.map((statText, index) => {
+    const stringifiedJson = statText.replace('Stats ', '')
+    const stat = JSON.parse(normalizeJson(stringifiedJson))
+    return {
+      ...stat,
+      date: commits[index].commit.author.date,
+    }
+  })
+  return stats
+}
+
+export const getChartableStats = async (ghToken, owner, repo, filename) => {
+  const options = {
+    responsive: true,
+    spanGaps: true,
+    showLine: true,
+    scales: {
+      x: {
+        type: 'time',
+        time: {
+          unit: 'week',
+        },
+      },
+    },
+    plugins: {
+      legend: {
+        position: 'top'
+      },
+      title: {
+        display: false,
+        text: 'STC Development Progress'
+      },
+    }
+  }
+
+  const stats = await getStats(ghToken, owner, repo, filename)
+
+  const data = {
+    datasets: [
+      {
+        label: 'Required',
+        data: stats.map((s) => {
+          return {
+            x: s.date,
+            y: s.required_error,
+          }
+        }),
+        borderColor: '#57A0E5',
+        backgroundColor: '#57A0E5',
+      },
+      {
+        label: 'Matched',
+        data: stats.map((s) => {
+          return {
+            x: s.date,
+            y: s.matched_error,
+          }
+        }),
+        borderColor: '#9268F6',
+        backgroundColor: '#9268F6',
+      },
+      {
+        label: 'Extra',
+        data: stats.map((s) => {
+          return {
+            x: s.date,
+            y: s.extra_error,
+          }
+        }),
+        borderColor: '#6DBEBF',
+        backgroundColor: '#6DBEBF',
+      },
+      {
+        label: 'Panic',
+        data: stats.map((s) => {
+          return {
+            x: s.date,
+            y: s.panic,
+          }
+        }),
+        borderColor: '#ED6D85',
+        backgroundColor: '#ED6D85',
+      },
+    ]
+  }
+
+  return {
+    options,
+    data,
+  }
+}
+
+export const getStaticProps = async ({ params }) => {
+    const ghToken = process.env.GITHUB_TOKEN
+    const owner = 'dudykr'
+    const repo = 'stc'
+    const filename = 'crates/stc_ts_type_checker/tests/tsc-stats.rust-debug'
+    const data = await getChartableStats(ghToken, owner, repo, filename)
+    return {
       props: {
         // We add an `ssg` field to the page props,
         // which will be provided to the Nextra `useSSG` hook.
         ssg: {
-          content: repo.content
-        }
+          content: btoa(JSON.stringify(data)),
+        },
       },
       // The page will be considered as stale and regenerated every 1 hour.
-      revalidate: 60 * 60
-    }))
+      revalidate: 60 * 60,
+    }
 }
  
 export const Stats = () => {
+    ChartJS.register(
+      LinearScale,
+      TimeScale,
+      PointElement,
+      LineElement,
+      Title,
+      Tooltip,
+      Legend
+  )
     // Get the data from SSG, and render it as a component.
     const { content } = useSSG()
-    return <pre>{decodeURIComponent(escape(atob(content)))}</pre>
+    const { options, data } = JSON.parse(decodeURIComponent(escape(atob(content))))
+    return <Line data={data} width={100} height={40} options={options}/>
 }
 
 The fastest TypeScript type checker written in Rust.
@@ -31,15 +169,16 @@ The fastest TypeScript type checker written in Rust.
 ## Status
 
 `stc` is under active development.
-To provide an estimate of the progress, we have a stats.
+To provide an estimate of the progress, we provide historical statistics.
 
 
 <Stats />
 
- - `required_error` means a true negative, which is a type error that is not reported by `stc`.
+ - <strong>Required</strong> means a true negative, which is a type error that is not reported by `stc`.
 
- - `matched_error` means a true positive, which is a type error that is reported by `stc` and correct.
+ - <strong>Matched</strong> means a true positive, which is a type error that is reported by `stc` and correct.
 
- - `extra_error` means a false positive. In other words, it's the number of incorrect errors `stc` emits while it should not.
+ - <strong>Extra</strong> means a false positive. In other words, it's the number of incorrect errors `stc` emits while it should not.
 
- - `panic` means the analyzer panicked while validating input files, due to a logic bug.
+ - <strong>Panic</strong> means the analyzer panicked while validating input files, due to a logic bug.
+ 


### PR DESCRIPTION
@kdy1 Following up on https://twitter.com/thundubeedi/status/1614481175401345025?s=20

I hope this helps!

**Summary of changes**

1. Add Chart.js for charting library and `date-fns` for automatic scaling of the time axis.
2. Updated SSP logic to fetch all commit history of the stats file, then fetch every version of the file, and parse the JSON from it.
3. This change now requires `$GITHUB_TOKEN` (best to use your own personal Github token scoped to the `stc` repo and with only `repo:*` permissions) to be set up so that you don't get rate-limited.

If you'd like any changes, let me know!