### PR TITLE
feat: enable pagination, display last 100 commits

### DIFF
--- a/sites/stc/pages/index.mdx
+++ b/sites/stc/pages/index.mdx
@@ -23,12 +23,16 @@ export const getCommits = async (ghToken, owner, repo, filename) => {
   if (!ghToken || !ghToken.length) {
     throw new Error('Github API token missing! Please configure it with the environment variable GITHUB_TOKEN')
   }
-  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/commits?path=${filename}`, {
-    headers: {
-      'Authorization': `token ${ghToken}`,
-    },
+  let commitsPromises = Array(5).fill(null).map(async (_, i) => {
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/commits?path=${filename}&since=2022-11-11T00:00:00Z&per_page=20&page=${i + 1}`, {
+      headers: {
+        'Authorization': `token ${ghToken}`,
+      },
+    })
+    return await response.json()
   })
-  const json = await response.json()
+
+  const json = (await Promise.all(commitsPromises)).reduce((acc, curr) => acc.concat(curr))
   return json
 }
 
@@ -147,7 +151,7 @@ export const getStaticProps = async ({ params }) => {
       revalidate: 60 * 60,
     }
 }
- 
+
 export const Stats = () => {
     ChartJS.register(
       LinearScale,
@@ -181,4 +185,3 @@ To provide an estimate of the progress, we provide historical statistics.
  - <strong>Extra</strong> means a false positive. In other words, it's the number of incorrect errors `stc` emits while it should not.
 
  - <strong>Panic</strong> means the analyzer panicked while validating input files, due to a logic bug.
- 


### PR DESCRIPTION
This PR enables pagination for the stats display, and displays the last 100 commits, instead of the 30 previously displayed.

the since parameter in the url is when the tsc-stats.rust-debug file was first introduced