### PR TITLE
fix: responsiveness issue for status chart

### DIFF
--- a/sites/stc/pages/index.mdx
+++ b/sites/stc/pages/index.mdx
@@ -55,6 +55,7 @@ export const getStats = async (ghToken, owner, repo, filename) => {
 export const getChartableStats = async (ghToken, owner, repo, filename) => {
   const options = {
     responsive: true,
+    maintainAspectRatio: false,
     spanGaps: true,
     showLine: true,
     scales: {
@@ -165,7 +166,7 @@ export const Stats = () => {
     // Get the data from SSG, and render it as a component.
     const { content } = useSSG()
     const { options, data } = JSON.parse(decodeURIComponent(escape(atob(content))))
-    return <Line data={data} width={100} height={40} options={options}/>
+    return <Line style={{ maxHeight: 330 }} data={data} width={100} options={options}/>
 }
 
 The fastest TypeScript type checker written in Rust.


### PR DESCRIPTION
## Before
![Screenshot from 2023-02-03 15-04-19](https://user-images.githubusercontent.com/33938500/216623108-95dab992-335f-4c4a-81bd-2273b9940df0.png)

## After
![Screenshot from 2023-02-03 15-04-39](https://user-images.githubusercontent.com/33938500/216623149-a686d749-75fc-4109-a5a4-9c6bb1112149.png)

I used 330px because it's pretty much just like the current height.